### PR TITLE
Add Developer Support for Custom Arduino Libraries in Code Panel

### DIFF
--- a/wwwroot/lib/compile-util.ts
+++ b/wwwroot/lib/compile-util.ts
@@ -33,23 +33,73 @@ export interface IHexiResult {
 
 export async function buildHex(source: string) {
     const include = Array.from(source.matchAll(/#include <([^>]+)>/g)).map(match => match[1]);
+    
     const renameInclude = include.map(lib => library[lib]).filter(lib => lib !== undefined);
-
+    
     let listString = "";
-    listString += renameInclude.join("\n") + "\n";
+    listString += renameInclude
+        .filter(lib => !lib.startsWith("local/"))
+        .join("\n") + "\n";
+    
+    const files: { name: string; content: string }[] = [
+        {
+            name: "libraries.txt",
+            content: listString
+        }
+    ];
+
+    // Add local libraries (.h/.cpp from ./libraries folder)
+    for (const lib of renameInclude) {
+        if (lib.startsWith("local/")) {
+            const libName = lib.replace("local/", "");
+            const basePath = `/libraries/${libName}`;
+
+            // always include header
+            const header = await fetch(`${basePath}/${libName}.h`).then(r => r.text());
+            files.push({ name: `libraries/${libName}/${libName}.h`, content: header });
+
+            // Look for nested libraries
+            const nestedIncludes = Array.from(header.matchAll(/#include <([^>]+)>/g)).map(m => m[1]);
+            for (const nested of nestedIncludes) {
+                if (library[nested]?.startsWith("local/")) {
+                    const nestedName = library[nested].replace("local/", "");
+                    const nestedPath = `/libraries/${nestedName}`;
+                    const nestedHeader = await fetch(`${nestedPath}/${nestedName}.h`).then(r => r.text());
+                    files.push({ name: `libraries/${nestedName}/${nestedName}.h`, content: nestedHeader });
+
+                    // Look for cpp file
+                    try {
+                        const resp = await fetch(`${nestedPath}/${nestedName}.cpp`);
+                        if (resp.ok) {
+                            const src = await resp.text();
+                            files.push({ name: `libraries/${nestedName}/${nestedName}.cpp`, content: src });
+                        }
+                    } catch {}
+                }
+            }
+
+            // Look for cpp file
+            try {
+                const resp = await fetch(`${basePath}/${libName}.cpp`);
+                if (resp.ok) {
+                    const sourceFile = await resp.text();
+                    files.push({ name: `libraries/${libName}/${libName}.cpp`, content: sourceFile });
+                }
+            } catch {}
+        }
+    }
+    
     const resp = await fetch(url + '/build', {
         method: 'POST',
         mode: 'cors',
         cache: 'no-cache',
-        headers: {
-            'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-            files: [{
-                name: "libraries.txt",
-                content: listString
-            }], sketch: source, board: AVRRunner.getInstance().boardConstructor == ArduinoUno ? "" : "mega"
+            files,
+            sketch: source,
+            board: AVRRunner.getInstance().boardConstructor == ArduinoUno ? "" : "mega"
         })
     });
+
     return (await resp.json()) as IHexiResult;
 }


### PR DESCRIPTION
[Example Libraries Folder](https://github.com/user-attachments/files/22688640/libraries.zip)

## Overview
This PR adds support for developers to use custom Arduino libraries. Developers can now add local header (`.h`) and/or source (`.cpp`) files, register them in the library dictionary, and use the functions defined in these libraries without errors.

This is primarily for if a component does not have a library available on Wokwi, but it also can be used if a developer would like to add their own functionality to the library. 

### Instructions for Testing
#### 1. Add Library Files
- Place your library `.h` and `.cpp` files in the folder: 
`wwwroot/libraries/<library_name>/`

#### 2. Register Library
- Add an entry for each library in `library_dictionary.ts`, where the key is the header file name, and the value is `"local/<header_name_without_extension>"`.
Example for `ph_surveyor` and `base_surveyor`:
```typescript
export const library = {
    // .......
    "ph_surveyor.h": "local/ph_surveyor",
    "base_surveyor.h": "local/base_surveyor"
}
```
> Note: If your library contains multiple headers, you may need to add each header file to this dictionary.

#### 3. Include Library in Code
- In the code panel, include the header:
```c++
#include <header_name.h>
```

### Example Code Using Included Libraries: 
```c++
#include <ph_surveyor.h>

int analogPin2 = 14;
Surveyor_pH phSensor(analogPin2);  

void setup() {
    // Initialize serial communication for debugging
    Serial.begin(9600);
    phSensor.begin(); 
}

void loop() {
    float voltage = phSensor.read_voltage();
    Serial.println(voltage);
    Serial.println(phSensor.read_ph());
    Serial.println(phSensor.read_ph(voltage));
}
```

#### Expected Behavior
- The sketch should compile and run without errors.
- All functions defined in the library should be usable as expected.
- The specific outputs are not important, only that the code runs without compilation/runtime errors