### PR TITLE
Potential Fix: Bypass browser HTTP cache when fetching ruleset manifests

### DIFF
--- a/RuleSetMap.cs
+++ b/RuleSetMap.cs
@@ -51,8 +51,9 @@ namespace ADArCWebApp
             client.BaseAddress = new(navigationManager.BaseUri + "rules/");
 
             // Load the ruleset, parse file contents rules, and save them for iteration to download individually
-            HttpResponseMessage ruleSetResponse =
-                await client.GetAsync(name + ".rsxml");
+            var manifestRequest = new HttpRequestMessage(HttpMethod.Get, name + ".rsxml");
+            manifestRequest.Headers.CacheControl = new System.Net.Http.Headers.CacheControlHeaderValue { NoCache = true };
+            HttpResponseMessage ruleSetResponse = await client.SendAsync(manifestRequest);
             XmlSerializer ruleDeserializer = new(typeof(ruleSet));
             Stream ruleSetFileContent = await ruleSetResponse.Content.ReadAsStreamAsync();
             var ruleReader = new StreamReader(ruleSetFileContent);


### PR DESCRIPTION
## Problem

When a new component rule is added to a `.rsxml` manifest file, the browser may serve a stale cached version of that manifest on subsequent loads.

As a result:

1. `LoadRuleSet` never creates an HTTP task for the new `.grxml` file.
2. The rule file is never fetched or loaded into `connect.rules`.
3. `GraphSynthInvoke.Connect()` throws a `RuleNotFoundException` at runtime.

## Fix

Add a `Cache-Control: no-cache` header specifically to the `.rsxml` manifest request in `RuleSetMap.LoadRuleSet`.

This forces the browser to revalidate the manifest with the server on every load, ensuring newly added rule entries are always discovered.

The individual `.grxml` rule files continue to use normal caching behavior. These files are static content and generally do not change between deployments, so caching them avoids unnecessary network round trips.

## Testing                                                                                                                                                                                                                   
  - [ ] Load the app once to populate the browser cache for CONNECT.rsxml                                                                                                                                                          
  - [ ] Add a new rule file name to CONNECT.rsxml (do NOT clear cache or hard-refresh)                                                                                                                                             
  - [ ] Reload normally (Ctrl+R, not Ctrl+Shift+R) and confirm the new .grxml file                                                                                                                                                 appears in the network tab and the component can be placed without a                                                                                                                                        RuleNotFoundException                                                                                                                                         
  - [ ] Hard-refresh (Ctrl+Shift+R) and confirm everything still works     